### PR TITLE
Add AzuFight and Hinokakera configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,6 @@ More features coming soon™.
 ## Game-specific tweaks
 Some games ship with default keyboard mappings that may not interact nicely with the keyboard interaction library shipped with this program or the gane itself. This requires some user input, see changes below:
 
+- AzuFight Taisen Shiyo: Reset keyconfig to default by removing "keyconfig.dat" from the game folder
 - Battle Fantasia: Set both players to use Keyboard input. Keep all mappings to default, **except** changing Player 2 "Start" to "Numpad +", from "Numpad Enter".
 - The Queen of Heart '99: Keep default controls, **except** changing Player 4 "Left" to "B", from "Delete" because delete is a bind to go back to the main menu. The keybinding screen can be glitchy, I needed to press "0" to swap it to "B".

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ Currently this uses a pre-release version of enigo that has support for the nump
 Current configuration files in the repo:
 - 2D Fighter Maker 2nd (Generic Bindings)
 - 2D Fighter Maker 95 (Generic Bindings)
+- AzuFight: Taisen Shiyo
 - Battle Fantasia
 - Comic Party Wars 2
+- Hinokakera Chaotic Eclipse
 - The Queen of Heart '99
 - Touhou 3: Phantasmagoria of Dim. Dream
 - Wonderful World

--- a/config/azufight.json
+++ b/config/azufight.json
@@ -1,0 +1,83 @@
+{
+  "name": "Azufight",
+  "controls": [
+    {
+      "directions": {
+        "Up": "UpArrow",
+        "Down": "DownArrow",
+        "Left": "LeftArrow",
+        "Right": "RightArrow"
+      },
+      "actions": [
+        [
+          "A",
+          {
+            "Unicode": "n"
+          }
+        ],
+        [
+          "B",
+          {
+            "Unicode": "m"
+          }
+        ],
+        [
+          "C",
+          {
+            "Unicode": ","
+          }
+        ],
+        [
+          "SP",
+          {
+            "Unicode": "."
+          }
+        ],
+        [
+          "Pause",
+          "F5"
+        ]
+      ]
+    },
+    {
+      "directions": {
+        "Up": "T",
+        "Down": "V",
+        "Left": "F",
+        "Right": "G"
+      },
+      "actions": [
+        [
+          "A",
+          {
+            "Unicode": "a"
+          }
+        ],
+        [
+          "B",
+          {
+            "Unicode": "z"
+          }
+        ],
+        [
+          "C",
+          {
+            "Unicode": "x"
+          }
+        ],
+        [
+          "SP",
+          {
+            "Unicode": "c"
+          }
+        ],
+        [
+          "Pause",
+          {
+            "Unicode": "d"
+          }
+        ]
+      ]
+    }
+  ]
+}

--- a/config/hinokakera.json
+++ b/config/hinokakera.json
@@ -1,0 +1,89 @@
+{
+  "name": "Hinokakera.\n* Launch the game before connecting controllers",
+  "controls": [
+    {
+      "directions": {
+        "Left": {
+          "Unicode": "g"
+        },
+        "Right": {
+          "Unicode": "j"
+        },
+        "Up": {
+          "Unicode": "y"
+        },
+        "Down": {
+          "Unicode": "h"
+        }
+      },
+      "actions": [
+        [
+          "A",
+          {
+            "Unicode": "z"
+          }
+        ],
+        [
+          "B",
+          {
+            "Unicode": "x"
+          }
+        ],
+        [
+          "C",
+          {
+            "Unicode": "c"
+          }
+        ],
+        [
+          "D",
+          {
+            "Unicode": "v"
+          }
+        ],
+        [
+          "Pause",
+          "F1"
+        ]
+      ]
+    },
+    {
+      "directions": {
+        "Left": "LeftArrow",
+        "Right": "RightArrow",
+        "Up": "UpArrow",
+        "Down": "DownArrow"
+      },
+      "actions": [
+        [
+          "A",
+          {
+            "Unicode": ","
+          }
+        ],
+        [
+          "B",
+          {
+            "Unicode": "."
+          }
+        ],
+        [
+          "C",
+          {
+            "Unicode": "/"
+          }
+        ],
+        [
+          "D",
+          {
+            "Unicode": "\\"
+          }
+        ],
+        [
+          "Pause",
+          "F1"
+        ]
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Also added a note to the README for resetting keybinds in AzuFight:
- Community Edition has double-bound keyboard inputs saved
- AzuFight keyboard bindings can't be changed on Win10/Win11, so removing "keyconfig.dat" from the game files and letting the program recreate it is an easy solution